### PR TITLE
Add admin user for kubernetes dashboard

### DIFF
--- a/roles/post-scripts/defaults/main.yaml
+++ b/roles/post-scripts/defaults/main.yaml
@@ -5,5 +5,6 @@ dns_server_soft: coredns
 cluster_dns_ip: 10.32.0.10 
 ingress_controller: traefik
 k8s_dashboard: true
+k8s_dashboard_admin: true
 service_mesh: linkerd
 linkerd_release: stable-2.6.0

--- a/roles/post-scripts/tasks/default_dashboard.yaml
+++ b/roles/post-scripts/tasks/default_dashboard.yaml
@@ -18,3 +18,62 @@
     state: absent
     path: "{{ dashboard_tempdir.path }}"
   changed_when: false
+
+- name: Check dashboard admin user
+  command: kubectl get serviceaccounts -n kubernetes-dashboard dashboardadmin
+  register: check_dashboard_admin
+  ignore_errors: true
+  when:
+    - k8s_dashboard_admin
+
+
+- name: Create dashboard admin user
+  command: kubectl create serviceaccount dashboardadmin -n kubernetes-dashboard
+  register: create_dashboard_admin
+  changed_when: >
+    create_dashboard_admin.stdout is search("created")
+    or create_dashboard_admin.stdout is search("configured")
+  when:
+    - k8s_dashboard_admin
+    - check_dashboard_admin.stderr is search("NotFound")
+
+- name: Check cluster role binding for admin user
+  command: kubectl get clusterrolebinding agora-dashboard-admin-role-binding
+  register: check_dashboard_admin_role
+  ignore_errors: true
+  when:
+    - k8s_dashboard_admin
+
+- name: Create cluster role binding for admin user
+  command: kubectl create clusterrolebinding agora-dashboard-admin-role-binding  --clusterrole=cluster-admin  --serviceaccount=kubernetes-dashboard:dashboardadmin
+  register: create_dashboard_admin_role
+  changed_when: >
+    create_dashboard_admin_role.stdout is search("created")
+    or create_dashboard_admin_role.stdout is search("configured")
+  when:
+    - k8s_dashboard_admin
+    - check_dashboard_admin_role.stderr is search("NotFound")
+
+- name: Get the admin service account
+  command: 'kubectl get serviceaccount -n kubernetes-dashboard dashboardadmin -o jsonpath="{.secrets[0].name}"'
+  register: dashboard_admin_service_account
+  when:
+    - k8s_dashboard_admin
+    - create_dashboard_admin.changed
+
+- name: Get the admin token
+  command: "kubectl get secret -n kubernetes-dashboard {{ dashboard_admin_service_account.stdout }}  -o jsonpath=\"{.data.token}\""
+  register: dashboard_admin_token
+  when:
+    - k8s_dashboard_admin
+    - create_dashboard_admin.changed
+
+- name:  "Copying dashboard admin token in /root/.kube/dashboardadmin, Please copy and store the token to safe place, it will only be stored once"
+  copy:
+    content: "{{ dashboard_admin_token.stdout | b64decode }}"
+    dest: /root/.kube/dashboardadmin
+  when:
+    - k8s_dashboard_admin
+    - dashboard_admin_token.changed
+
+


### PR DESCRIPTION
- Admin user will only be created if k8s_dashbaord_admin is set to true
- The admin token will be stored only when the user is created

Fixes #36