### PR TITLE
Add support for installation info

### DIFF
--- a/agorakube.yaml
+++ b/agorakube.yaml
@@ -31,3 +31,7 @@
     - install-kubectl
     - configure-kubeconfig
     - post-scripts
+- hosts: deploy
+  become: true
+  roles:
+    - show-info

--- a/roles/show-info/tasks/main.yml
+++ b/roles/show-info/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Store info file in /root
+  template:
+    src: info.j2
+    dest: /root/agorakube-info.txt
+    owner: root
+    group: root
+    mode: '0640'
+
+- name: Get file content to show to the user
+  command: cat /root/agorakube-info.txt
+  register: agora_info
+
+
+- name: Show informaiton to the user
+  debug:
+    var: agora_info.stdout_lines

--- a/roles/show-info/templates/info.j2
+++ b/roles/show-info/templates/info.j2
@@ -1,0 +1,38 @@
+
+
+#################################################################
+###            AgoreKube Installation Information             ###
+#################################################################
+
+
+Thank you for using AgoraKube to deploy and manage your Kubernetes installation.
+
+This file (agorakube-info.txt) is stored in root home directory for your reference.
+
+#############################################################
+
+##################
+# Kubectl config #
+##################
+Kubectl config file is located at: /root/.kube/config
+
+{% if k8s_dashboard is sameas true %}
+########################
+# Kubernetes Dashboard #
+########################
+Kubernetes dashboard can be accessed by following the steps below:
+
+1. Run follwoing command on deploy (ansible control) machine.
+# kubectl proxy
+
+2. Visit following URL on deploy machine.
+http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/
+
+{% if k8s_dashboard_admin is sameas true %}
+3. The Admin token is stored in: /root/.kube/dashboardadmin
+{% endif %}
+{% endif %}
+
+
+   Run following command to see this information again anytime.
+   $ cat /root/agorakube-info.txt


### PR DESCRIPTION
- The installation info is shown at the end of execution
- The installation info is also stored in /root/agorakube-info.txt
- Installation information also includes check k8s_dashboard and will
only display dashboard info if k8s_dashboard is set to true

Fixes #35 