### PR TITLE
Add CentOS Support

### DIFF
--- a/roles/generate-certs/tasks/gen-certs.yaml
+++ b/roles/generate-certs/tasks/gen-certs.yaml
@@ -36,6 +36,9 @@
   shell: 'cfssl gencert -initca "{{ data_path }}/certificates/ca/ca-csr.json" | cfssljson -bare "{{ data_path }}/certificates/ca/ca"'
   args:
     creates: "{{ data_path }}/certificates/ca/ca-key.pem"
+    executable: /bin/bash
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
 - name: Generate intermediate certificates
   template:
@@ -50,6 +53,8 @@
   shell: 'cfssl gencert -initca "{{ data_path }}/certificates/intermediate/{{ item }}/{{ item }}-csr.json" | cfssljson -bare "{{ data_path }}/certificates/intermediate/{{ item }}/{{ item }}"'
   args:
     creates: "{{ data_path }}/certificates/intermediate/{{ item }}/{{ item }}-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - kubernetes-front-proxy-ca
     - kubernetes-ca
@@ -64,6 +69,8 @@
   shell: 'cfssl sign -ca "{{ data_path }}/certificates/ca/ca.pem"  -ca-key "{{ data_path }}/certificates/ca/ca-key.pem"  -config "{{ data_path }}/certificates/ca/root_to_intermediate.json" "{{ data_path }}/certificates/intermediate/{{ item }}/{{ item }}.csr"   | cfssljson -bare "{{ data_path }}/certificates/intermediate/{{ item }}/signed/{{ item }}"'
   args:
     creates: "{{ data_path }}/certificates/intermediate/{{ item }}/signed/{{ item }}.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - kubernetes-front-proxy-ca
     - kubernetes-ca
@@ -117,6 +124,8 @@
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/etcd-ca/signed/etcd-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/etcd-ca/etcd-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json"  -profile client  "{{ data_path }}/certificates/end/{{item}}/{{item}}-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/{{item}}/{{item}}"'
   args:
     creates: "{{ data_path }}/certificates/end/{{ item }}/{{ item }}-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - kube-etcd-healthcheck-client
     - kube-apiserver-etcd-client
@@ -124,28 +133,38 @@
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/etcd-ca/signed/etcd-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/etcd-ca/etcd-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json" -profile client -profile server "{{ data_path }}/certificates/end/kube-etcd-peer/{{item}}/kube-etcd-peer-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/kube-etcd-peer/{{item}}/kube-etcd-peer"'
   args:
     creates: "{{ data_path }}/certificates/end/kube-etcd-peer/{{item}}/kube-etcd-peer-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['etcd'] }}"
 
 - name: generate certificate [kube-etcd]
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/etcd-ca/signed/etcd-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/etcd-ca/etcd-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json" -profile client -profile server "{{ data_path }}/certificates/end/kube-etcd/kube-etcd-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/kube-etcd/kube-etcd"'
   args:
     creates: "{{ data_path }}/certificates/end/kube-etcd/kube-etcd-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
 - name : generate certificate [kube-apiserver]
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-ca/kubernetes-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json" -profile server  "{{ data_path }}/certificates/end/kube-apiserver/{{ item }}/kube-apiserver-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/kube-apiserver/{{ item }}/kube-apiserver"'
   args:
     creates: "{{ data_path }}/certificates/end/kube-apiserver/{{ item }}/kube-apiserver-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name: generate certificate [kube-apiserver-kubelet-client]
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-ca/kubernetes-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json" -profile client  "{{ data_path }}/certificates/end/kube-apiserver-kubelet-client/kube-apiserver-kubelet-client-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/kube-apiserver-kubelet-client/kube-apiserver-kubelet-client"'
   args:
     creates: "{{ data_path }}/certificates/end/kube-apiserver-kubelet-client/kube-apiserver-kubelet-client-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
 - name: generate certificate [front-proxy-client]
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-front-proxy-ca/signed/kubernetes-front-proxy-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-front-proxy-ca/kubernetes-front-proxy-ca-key.pem"  -config "{{ data_path }}/certificates/intermediate/intermediate_to_end.json" -profile client  "{{ data_path }}/certificates/end/front-proxy-client/front-proxy-client-csr.json" | cfssljson -bare "{{ data_path }}/certificates/end/front-proxy-client/front-proxy-client"'
   args:
     creates: "{{ data_path }}/certificates/end/front-proxy-client/front-proxy-client-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
 
 - name: create configuration files for config [admin] [controller-manager] [scheduler]
   template:
@@ -156,10 +175,13 @@
     - { name: 'controller-manager', o: '', cname: 'system:kube-controller-manager' }
     - { name: 'scheduler', o: '', cname: 'system:kube-scheduler' }
     - { name: 'proxier', o: '', cname: 'system:kube-proxy' }
+
 - name: generation des certificats pour [admin] [controller-manager] [scheduler]
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-ca/kubernetes-ca-key.pem"  "{{ data_path }}/certificates/configs/{{ item }}/{{ item }}-csr.json" | cfssljson -bare "{{ data_path }}/certificates/configs/{{ item }}/{{ item }}"'
   args:
     creates: "{{ data_path }}/certificates/configs/{{ item }}/{{ item }}-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - admin
     - controller-manager
@@ -188,6 +210,8 @@
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-ca/kubernetes-ca-key.pem"  "{{ data_path }}/certificates/configs/kubelet/{{ item }}/config-kubelet-account.json" | cfssljson -bare "{{ data_path }}/certificates/configs/kubelet/{{ item }}/kubelet"'
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{ item }}/kubelet-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name : generate configuration account kubelet workers
@@ -200,12 +224,16 @@
   shell: 'cfssl gencert -ca "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" -ca-key "{{ data_path }}/certificates/intermediate/kubernetes-ca/kubernetes-ca-key.pem"  "{{ data_path }}/certificates/configs/kubelet/{{ item }}/config-kubelet-account.json" | cfssljson -bare "{{ data_path }}/certificates/configs/kubelet/{{ item }}/kubelet"'
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{ item }}/kubelet-key.pem"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['workers'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [proxier]
   shell: "{{ item }}"
   args:
     creates: "{{ data_path }}/certificates/configs/proxier/proxier.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - KUBECONFIG="{{ data_path }}/certificates/configs/proxier/proxier.conf" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
     - KUBECONFIG="{{ data_path }}/certificates/configs/proxier/proxier.conf" kubectl config set-credentials system:kube-proxy --client-key "{{ data_path }}/certificates/configs/proxier/proxier-key.pem" --client-certificate "{{ data_path }}/certificates/configs/proxier/proxier.pem" --embed-certs
@@ -217,6 +245,8 @@
   shell: "{{ item }}"
   args:
     creates: "{{ data_path }}/certificates/configs/admin/admin.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - KUBECONFIG="{{ data_path }}/certificates/configs/admin/admin.conf" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
     - KUBECONFIG="{{ data_path }}/certificates/configs/admin/admin.conf" kubectl config set-credentials default-admin --client-key "{{ data_path }}/certificates/configs/admin/admin-key.pem" --client-certificate "{{ data_path }}/certificates/configs/admin/admin.pem" --embed-certs
@@ -228,6 +258,8 @@
   shell: "{{ item }}"
   args:
     creates: "{{ data_path }}/certificates/configs/controller-manager/controller-manager.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - KUBECONFIG="{{ data_path }}/certificates/configs/controller-manager/controller-manager.conf" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
     - KUBECONFIG="{{ data_path }}/certificates/configs/controller-manager/controller-manager.conf" kubectl config set-credentials default-controller-manager --client-key "{{ data_path }}/certificates/configs/controller-manager/controller-manager-key.pem" --client-certificate "{{ data_path }}/certificates/configs/controller-manager/controller-manager.pem" --embed-certs
@@ -239,6 +271,8 @@
   shell: "{{ item }}"
   args:
     creates: "{{ data_path }}/certificates/configs/scheduler/scheduler.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items:
     - KUBECONFIG="{{ data_path }}/certificates/configs/scheduler/scheduler.conf" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
     - KUBECONFIG="{{ data_path }}/certificates/configs/scheduler/scheduler.conf" kubectl config set-credentials default-manager --client-key "{{ data_path }}/certificates/configs/scheduler/scheduler-key.pem" --client-certificate "{{ data_path }}/certificates/configs/scheduler/scheduler.pem" --embed-certs
@@ -250,24 +284,32 @@
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] masters 2/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-credentials default-auth --client-key "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet-key.pem" --client-certificate "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.pem" --embed-certs
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] masters 3/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-context default-system --cluster default-cluster --user default-auth
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] masters 4/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config use-context default-system
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['masters'] }}"
 
 - name: Create flags [Modifier plus tard !!]
@@ -281,24 +323,32 @@
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-cluster default-cluster --server=https://{{advertise_ip_masters}}:6443 --certificate-authority "{{ data_path }}/certificates/intermediate/kubernetes-ca/signed/kubernetes-ca.pem" --embed-certs
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['workers'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] workers 2/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-credentials default-auth --client-key "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet-key.pem" --client-certificate "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.pem" --embed-certs
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['workers'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] workers 3/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config set-context default-system --cluster default-cluster --user default-auth
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['workers'] }}"
 
 - name: Generation fichier de configuration kubeconfig pour [kubelet] workers 4/4
   shell: KUBECONFIG="{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.config" kubectl config use-context default-system
   args:
     creates: "{{ data_path }}/certificates/configs/kubelet/{{item}}/kubelet.flag"
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
   with_items: "{{ groups['workers'] }}"
 
 - name: Create flags [Modifier plus tard !!] workers

--- a/roles/generate-certs/tasks/install-cfssl-cfssljson.yaml
+++ b/roles/generate-certs/tasks/install-cfssl-cfssljson.yaml
@@ -1,7 +1,13 @@
 ---
 - name: Install gcc
-  apt:
+  package:
     name: gcc
+    state: latest
+
+# Git is required for the Install cfssl task, Centos does not come with git installed
+- name: Install gcc
+  package:
+    name: git
     state: latest
 - name: Install cfssl
   shell: source /etc/profile && go get -u github.com/cloudflare/cfssl/cmd/cfssl

--- a/roles/generate-certs/tasks/main.yaml
+++ b/roles/generate-certs/tasks/main.yaml
@@ -6,3 +6,4 @@
   when: update_certs
 - name: generate certificates and configs
   include_tasks: gen-certs.yaml
+

--- a/roles/install-kubectl/tasks/main.yaml
+++ b/roles/install-kubectl/tasks/main.yaml
@@ -1,19 +1,6 @@
 ---
-- name: Install apt-transport-https
-  apt:
-    name: apt-transport-https
-    state: present
-    update_cache: yes
-- name: Add apt key for kubectl
-  apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    state: present
-- name: add repo [deb https://apt.kubernetes.io/ kubernetes-xenial main]
-  apt_repository:
-    repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
-    state: present
-- name: Install Kubectl
-  apt:
-    name: kubectl
-    state: present
-    update_cache: yes
+- name: Setup kubectl's {{ ansible_distribution }} repo
+  include_tasks: "repo-{{ ansible_distribution }}.yaml"
+
+- name: Install kubectl
+  package: name=kubectl state=present

--- a/roles/install-kubectl/tasks/repo-CentOS.yaml
+++ b/roles/install-kubectl/tasks/repo-CentOS.yaml
@@ -1,0 +1,11 @@
+---
+- name: Add kubectl repository
+  yum_repository:
+    name: Kubernetes
+    description: Kubernetes YUM repo
+    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+    gpgcheck: yes
+    repo_gpgcheck: yes
+    gpgkey:
+      - https://packages.cloud.google.com/yum/doc/yum-key.gpg 
+      - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/roles/install-kubectl/tasks/repo-Ubuntu.yaml
+++ b/roles/install-kubectl/tasks/repo-Ubuntu.yaml
@@ -1,0 +1,15 @@
+---
+- name: Install apt-transport-https
+  apt:
+    name: apt-transport-https
+    state: present
+    update_cache: yes
+- name: Add apt key for kubectl
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
+- name: add repo [deb https://apt.kubernetes.io/ kubernetes-xenial main]
+  apt_repository:
+    repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+    state: present
+

--- a/roles/install-runtimes/tasks/containerd.yaml
+++ b/roles/install-runtimes/tasks/containerd.yaml
@@ -19,27 +19,13 @@
     - { name: 'net.ipv4.ip_forward', value: '1' }
     - { name: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
 
-- name: Install packages to allow apt to use a repository over HTTPS
-  apt:
-    name: ['apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common']
-    state: latest
-    update_cache: yes
-- name: Add Docker’s official GPG key
-  apt_key:
-    url: https://download.docker.com/linux/ubuntu/gpg
-    state: present
-
-- name: Add Docker apt repository
-  apt_repository:
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable
-    state: present
-    update_cache: yes
+- name: Setup repo and install required packages for {{ ansible_distribution }}
+  include_tasks: "repo-{{ ansible_distribution }}.yaml"
 
 - name: Install containerd
-  apt:
+  package:
     name: containerd.io
     state: latest
-    update_cache: yes
 
 - name: Create /etc/containerd directory
   file:

--- a/roles/install-runtimes/tasks/repo-CentOS.yaml
+++ b/roles/install-runtimes/tasks/repo-CentOS.yaml
@@ -1,0 +1,16 @@
+---
+- name: "Install {{ item }}"
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - yum-utils
+    - device-mapper-persistent-data 
+    - lvm2
+
+- name: Add docker repository
+  shell: yum-config-manager  --add-repo  https://download.docker.com/linux/centos/docker-ce.repo
+  args:
+    creates: /etc/yum.repos.d/docker-ce.repo
+
+

--- a/roles/install-runtimes/tasks/repo-Ubuntu.yaml
+++ b/roles/install-runtimes/tasks/repo-Ubuntu.yaml
@@ -1,0 +1,17 @@
+---
+- name: Install packages to allow apt to use a repository over HTTPS
+  apt:
+    name: ['apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common']
+    state: latest
+    update_cache: yes
+- name: Add Docker’s official GPG key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
+- name: Add Docker apt repository
+  apt_repository:
+    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable
+    state: present
+    update_cache: yes
+

--- a/roles/post-scripts/tasks/linkerd.yaml
+++ b/roles/post-scripts/tasks/linkerd.yaml
@@ -17,3 +17,6 @@
   when: "'linkerd' not in linkerd_is_installed.stdout"
   args:
     executable: /bin/bash
+  environment:
+    PATH: /usr/local/bin:{{ ansible_env.PATH }}
+

--- a/roles/setup-worker/tasks/setup-worker.yaml
+++ b/roles/setup-worker/tasks/setup-worker.yaml
@@ -1,9 +1,8 @@
 ---
 - name: Install packages [socat] [conntrack] [ipset]
-  apt:
+  package:
     name: ["socat", "conntrack", "ipset"]
     state: latest
-    update_cache: yes
 
 - name: Download Kubernetes node binaries
   unarchive:

--- a/roles/setup-worker/templates/kubelet-config.yaml.j2
+++ b/roles/setup-worker/templates/kubelet-config.yaml.j2
@@ -13,7 +13,9 @@ clusterDomain: "cluster.local"
 clusterDNS:
   - "{{cluster_dns_ip}}"
 podCIDR: "{{ pod_cidr }}"
+{% if ansible_distribution == "Ubuntu" %}
 resolvConf: "/run/systemd/resolve/resolv.conf"
+{% endif %}
 runtimeRequestTimeout: "15m"
 tlsCertFile: "/etc/kubernetes/pki/apiserver-kubelet-client.crt"
 tlsPrivateKeyFile: "/etc/kubernetes/pki/apiserver-kubelet-client.key"

--- a/test_lab/Vagrantfile
+++ b/test_lab/Vagrantfile
@@ -1,28 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$script = <<-SCRIPT
-#!/bin/bash
-export DEBIAN_FRONTEND=noninteractive
-if which ansible-playbook >/dev/null; then
-  echo "Ansible is already installed"
-else
-  apt-get update
-  apt-get install -yqq git software-properties-common
-  apt-add-repository --yes --update ppa:ansible/ansible
-  apt-get install -yqq ansible
-fi
-cd /agorakube
-ansible-playbook -i test_lab/hosts.vagrant agorakube.yaml
-if [ -f /root/agorakube-info.txt ]; then
-  cat /root/agorakube-info.txt
-fi
-SCRIPT
+$vagrant_box = "bento/ubuntu-18.04"
+#$vagrant_box = "centos/7"
 
 Vagrant.configure("2") do |config|
   # Node1 Block START
   #config.vm.define "node1" do |node1|
-  #    node1.vm.box = "bento/ubuntu-18.04"
+  #    node1.vm.box = $vagrant_box
   #    node1.vm.network "private_network", ip: "10.0.0.11"
   #    node1.vm.hostname = "node1"
   #    node1.vm.provider "virtualbox" do |vb|
@@ -34,7 +19,7 @@ Vagrant.configure("2") do |config|
 
   # Node2 Block START
   #config.vm.define "node2" do |node2|
-  #    node2.vm.box = "bento/ubuntu-18.04"
+  #    node2.vm.box = $vagrant_box
   #    node2.vm.network "private_network", ip: "10.0.0.12"
   #    node2.vm.hostname = "node2"
   #    node2.vm.provider "virtualbox" do |vb|
@@ -45,16 +30,17 @@ Vagrant.configure("2") do |config|
   # Node2 Block END
 
   config.vm.define "deploy" do |deploy|
-      deploy.vm.box = "bento/ubuntu-18.04"
+      deploy.vm.box = $vagrant_box
       deploy.vm.network :private_network, ip: "10.0.0.10"
       deploy.vm.hostname = "deploy"
       deploy.vm.provider "virtualbox" do |vb|
           vb.customize ["modifyvm", :id, "--memory", 2048]
           vb.customize ["modifyvm", :id, "--name", "deploy"] 
       end
-      deploy.vm.provision :shell, inline: $script
+      deploy.vm.provision :shell, path: 'scripts/init.sh'
   end
 
 
   config.vm.synced_folder "../", "/agorakube"
+  config.vm.synced_folder ".vagrant", "/vagrant/.vagrant"
 end

--- a/test_lab/scripts/init.sh
+++ b/test_lab/scripts/init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+if which ansible-playbook >/dev/null; then
+  echo "Ansible is already installed"
+else
+
+    # Determine OS platform
+    UNAME=$(uname | tr "[:upper:]" "[:lower:]")
+    # If Linux, try to determine specific distribution
+    if [ "$UNAME" == "linux" ]; then
+        # If available, use LSB to identify distribution
+        if [ -f /etc/lsb-release -o -d /etc/lsb-release.d ]; then
+            export DISTRO=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
+        # Otherwise, use release info file
+        else
+            export DISTRO=$(ls -d /etc/[A-Za-z]*[_-][rv]e[lr]* | grep -v "lsb" | cut -d'/' -f3 | cut -d'-' -f1 | cut -d'_' -f1)
+        fi
+    fi
+    # For everything else (or if above failed), just use generic identifier
+    [ "$DISTRO" == "" ] && export DISTRO=$UNAME
+    unset UNAME
+    echo "#$DISTRO#"
+    if [[ $DISTRO == centos* ]]; then
+        killall -9 yum
+        yum install epel-release -y
+        yum install ansible -y
+    elif [[ $DISTRO == Ubuntu* ]]; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update
+        apt-get install -yqq git software-properties-common
+        apt-add-repository --yes --update ppa:ansible/ansible
+        apt-get install -yqq ansible
+        add-apt-repository --yes --remove ppa:PPA_Name/ppa
+    else
+        echo "Unsupported Vagrant box"
+        exit
+    fi
+fi
+cd /agorakube
+ansible-playbook -i test_lab/hosts.vagrant agorakube.yaml
+if [ -f /root/agorakube-info.txt ]; then
+  cat /root/agorakube-info.txt
+fi
+


### PR DESCRIPTION
**The problem**
Agorakube didn't have CentOS Support and it would be great to make it
work with CentOS and RHEL based distributions.

**Challenges**
- The main challenge in the CentOS Support was to configure yum repositories for different
components instead of apt.

- The second challenge was the resolver as Ubuntu uses systemd resolver
which CentOS does not have, which is configured in kubelet config file.

**Other issues**
- CentOS does not have /usr/local/bin in the PATH by default and it does
not pick up the settings from /etc/profile in the single play-book
execution

**Solution**
- Move the repository configuration to separate task file and only include
the task file based on distribution

- Add the PATH environment variable to all tasks using shell module.

- Add the check for configuring systemd resolver and only use it if the
distribtuion is Ubuntu

Fixes #4 