### PR TITLE
Stop Ansible from showing checks as failed task

### DIFF
--- a/roles/post-scripts/tasks/default_dashboard.yaml
+++ b/roles/post-scripts/tasks/default_dashboard.yaml
@@ -9,7 +9,7 @@
 - name: Check dashboard admin user
   command: kubectl get serviceaccounts -n kubernetes-dashboard dashboardadmin
   register: check_dashboard_admin
-  ignore_errors: true
+  failed_when: check_dashboard_admin.rc > 1
   when:
     - k8s_dashboard_admin
 
@@ -27,7 +27,7 @@
 - name: Check cluster role binding for admin user
   command: kubectl get clusterrolebinding agora-dashboard-admin-role-binding
   register: check_dashboard_admin_role
-  ignore_errors: true
+  failed_when: check_dashboard_admin_role.rc > 1
   when:
     - k8s_dashboard_admin
 


### PR DESCRIPTION
The command to check for service account and cluster role returns
non-zero status if the service account and cluster role does not exist,
which makes Ansible show those tasks as failed which can cause
confusions for new users.

By using failed_when we can let Ansible know when the task should be
treated as failed and hence avoid un-necessary confusion