### PR TITLE
Feature/add iface selection flannel

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -217,6 +217,7 @@ This section is used to defined all custom features of your deployment.
 | --- | --- | --- |
 | `runtime` | Container runtime used in your deployment | <ul><li> **ContainerD** *(default)* </li><br/><li>  **Docker**  </li></ul>|
 | `network_cni_plugin` | CNI plugin used in your deployment | <ul><li> **Calico** </li><br/><li>  **Flannel** *(default)* </li></ul>|
+| `flannel_iface` | Indicate to Flannel the specific iface to be binded | <ul><li> **default** *(default - take the first iface)* </li><br/><li>  **Specific Iface**</li></ul>|
 | `ingress_controller` | Ingress Controller used in your deployment | <ul><li> **Traefik** *(default)* </li><br/><li>  **HAProxy**  </li><br/><li>  **nginx**  </li><br/><li>  **none**  </li></ul>|
 | `dns_server_soft` | DNS service used in your deployment | <ul><li> **CoreDNS** *(default)* </li></ul>|
 | `label_workers` | Fixed the label *node-role.kubernetes.io/worker* to all workers in your cluster | <ul><li> **false** </li><br/><li>  **true** *(default)* </li></ul>|

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -23,13 +23,13 @@ service_node_port_range: 30000-32767
 # Custom features
 runtime: containerd
 network_cni_plugin: flannel
-flannel_iface: eth1
+flannel_iface: default
 ingress_controller: traefik
 dns_server_soft: coredns
 populate_etc_hosts: yes
 k8s_dashboard: true
 update_certs: false
-service_mesh: none
+service_mesh: linkerd
 linkerd_release: stable-2.6.0
 install_helm: false
 init_helm: true

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -23,12 +23,13 @@ service_node_port_range: 30000-32767
 # Custom features
 runtime: containerd
 network_cni_plugin: flannel
+flannel_iface: eth1
 ingress_controller: traefik
 dns_server_soft: coredns
 populate_etc_hosts: yes
 k8s_dashboard: true
 update_certs: false
-service_mesh: linkerd
+service_mesh: none
 linkerd_release: stable-2.6.0
 install_helm: false
 init_helm: true

--- a/roles/post-scripts/defaults/main.yaml
+++ b/roles/post-scripts/defaults/main.yaml
@@ -7,3 +7,4 @@ k8s_dashboard: true
 k8s_dashboard_admin: true
 service_mesh: linkerd
 linkerd_release: stable-2.6.0
+flannel_iface: default

--- a/roles/post-scripts/templates/flannel.yaml.j2
+++ b/roles/post-scripts/templates/flannel.yaml.j2
@@ -187,6 +187,9 @@ spec:
         command:
         - /opt/bin/flanneld
         args:
+{% if 'default' != flannel_iface %}
+        - --iface={{ flannel_iface }}
+{% endif %}
         - --ip-masq
         - --kube-subnet-mgr
         resources:


### PR DESCRIPTION
By default Flannel is binded to the first network interface.
This PR add the possibility to chose the network on wich flannel will be binded.