### PR TITLE
enable Traefik https config by default

### DIFF
--- a/roles/post-scripts/templates/traefik.yaml.j2
+++ b/roles/post-scripts/templates/traefik.yaml.j2
@@ -74,6 +74,9 @@ spec:
         - name: http
           containerPort: 80
           hostPort: 80
+        - name: https
+          containerPort: 443
+          hostPort: 443
         - name: admin
           containerPort: 8080
         securityContext:
@@ -86,6 +89,9 @@ spec:
         - --api
         - --kubernetes
         - --logLevel=INFO
+        - --defaultentrypoints=http,https
+        - --entrypoints=Name:https Address::443 TLS
+        - --entrypoints=Name:http Address::80
 ---
 kind: Service
 apiVersion: v1
@@ -98,7 +104,10 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      name: web
+      name: http
+    - protocol: TCP
+      port: 443
+      name: https
     - protocol: TCP
       port: 8080
       name: admin


### PR DESCRIPTION
Actually, only HA-Proxy and Nginx Ingresses are configuraded with HTTPS enabled by default. 
This PR enable it for Traefik.