### PR TITLE
Feature/add advertise dns support

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,14 +1,13 @@
-
 ---
 # PKI info
 state_or_province_name: "Ile-De-France"
-locality_name: "Pairs"
+locality_name: "Paris"
 country_name: "FR"
-root_ca_common_name: "Kubernetes"
+root_ca_common_name: "kubernetes"
 expiry: "+3650d" # Default validity duration for PKI certificates.
 
 # PKI management parameters
-rotate_certificats: True # This parameter is used to renew K8S PKI certificats
+rotate_certificats: False # This parameter is used to renew K8S PKI certificats
 
 # Components version
 etcd_release: v3.4.10
@@ -25,20 +24,20 @@ cluster_dns_ip: 10.32.0.10
 service_node_port_range: 30000-32000
 cni_release: 0.8.6
 enable_metallb_layer2: True # If set to true, install metlab LB on your K8S cluster. This enable Service type LoadBalancer
-metallb_layer2_ips: 10.10.20.150-10.10.20.250 # Set Exeternal IP pool used by Service Type LoabBalancer "FistIP-LastIP"
+metallb_layer2_ips: 10.100.200.10-10.100.200.250 # Set Exeternal IP pool used by Service Type LoabBalancer "FistIP-LastIP"
+# metallb_secret_key is generated with command : openssl rand -base64 128
 metallb_secret_key: LGyt2l9XftOxEUIeFf2w0eCM7KjyQdkHform0gldYBKMORWkfQIsfXW0sQlo1VjJBB17shY5RtLg0klDNqNq4PAhNaub+olSka61LxV73KN2VaJY/snrZmHbdf/a7DfdzaeQ5pzP6D5O7zbUZwfb5ASOhNrG8aDMY3rkf4ZzHkc=
 
 # Custom features
-runtime: docker
+runtime: containerd
 ingress_controller: nginx
 populate_etc_hosts: True
 k8s_dashboard: True
 enable_metrics_server: True
-enable_persistence: True
-enable_monitoring: True
+enable_persistence: False
+enable_monitoring: False
 dashboard_admin_user: administrator
 dashboard_admin_password: P@ssw0rd
-
 # Security
 encrypt_etcd_keys:
 # Warrning: If multiple keys are defined ONLY LAST KEY is used for encrypt and decrypt.
@@ -50,5 +49,3 @@ encrypt_etcd_keys:
 data_path: "/var/agorakube"
 etcd_data_directory: "/var/lib/etcd"
 #restoration_snapshot_file: /path/snopshot/file Located on {{ etcd_data_directory }}
-
-

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,13 +1,14 @@
+
 ---
 # PKI info
 state_or_province_name: "Ile-De-France"
-locality_name: "Paris"
+locality_name: "Pairs"
 country_name: "FR"
-root_ca_common_name: "kubernetes"
+root_ca_common_name: "Kubernetes"
 expiry: "+3650d" # Default validity duration for PKI certificates.
 
 # PKI management parameters
-rotate_certificats: False # This parameter is used to renew K8S PKI certificats
+rotate_certificats: True # This parameter is used to renew K8S PKI certificats
 
 # Components version
 etcd_release: v3.4.10
@@ -24,20 +25,20 @@ cluster_dns_ip: 10.32.0.10
 service_node_port_range: 30000-32000
 cni_release: 0.8.6
 enable_metallb_layer2: True # If set to true, install metlab LB on your K8S cluster. This enable Service type LoadBalancer
-metallb_layer2_ips: 10.100.200.10-10.100.200.250 # Set Exeternal IP pool used by Service Type LoabBalancer "FistIP-LastIP"
-# metallb_secret_key is generated with command : openssl rand -base64 128
+metallb_layer2_ips: 10.10.20.150-10.10.20.250 # Set Exeternal IP pool used by Service Type LoabBalancer "FistIP-LastIP"
 metallb_secret_key: LGyt2l9XftOxEUIeFf2w0eCM7KjyQdkHform0gldYBKMORWkfQIsfXW0sQlo1VjJBB17shY5RtLg0klDNqNq4PAhNaub+olSka61LxV73KN2VaJY/snrZmHbdf/a7DfdzaeQ5pzP6D5O7zbUZwfb5ASOhNrG8aDMY3rkf4ZzHkc=
 
 # Custom features
-runtime: containerd
+runtime: docker
 ingress_controller: nginx
 populate_etc_hosts: True
 k8s_dashboard: True
 enable_metrics_server: True
-enable_persistence: False
-enable_monitoring: False
+enable_persistence: True
+enable_monitoring: True
 dashboard_admin_user: administrator
 dashboard_admin_password: P@ssw0rd
+
 # Security
 encrypt_etcd_keys:
 # Warrning: If multiple keys are defined ONLY LAST KEY is used for encrypt and decrypt.
@@ -49,3 +50,5 @@ encrypt_etcd_keys:
 data_path: "/var/agorakube"
 etcd_data_directory: "/var/lib/etcd"
 #restoration_snapshot_file: /path/snopshot/file Located on {{ etcd_data_directory }}
+
+

--- a/hosts
+++ b/hosts
@@ -13,10 +13,14 @@ worker20  ansible_host=10.10.20.50
 worker30  ansible_host=10.10.20.60
 
 [all:vars]
-advertise_masters=k8s.pierre.lan
+advertise_masters=k8s.pierre.localcluster.lan
+
 
 # SSH connection settings
 ansible_ssh_extra_args=-o StrictHostKeyChecking=no
 ansible_user=vagrant
 ansible_ssh_private_key_file=/home/vagrant/ssh-private-key.pem
 
+# If advertise_masters is a DNS and you want to to provision /etc/hosts file of your cluster hosts:
+[etc_hosts]
+k8s.pierre.localcluster.lan ansible_host=10.10.20.40

--- a/hosts
+++ b/hosts
@@ -1,17 +1,19 @@
 
 [deploy]
-kubernetes ansible_connection=local
+master ansible_connection=local
 
 [masters]
-kubernetes  ansible_host=10.20.20.4
+master  ansible_host=10.10.20.40
 
 [etcd]
-kubernetes  ansible_host=10.20.20.4
+master  ansible_host=10.10.20.40
+
 [workers]
-kubernetes  ansible_host=10.20.20.4
+worker20  ansible_host=10.10.20.50
+worker30  ansible_host=10.10.20.60
 
 [all:vars]
-advertise_ip_masters=10.20.20.4
+advertise_ip_masters=k8s.pierre.lan
 
 # SSH connection settings
 ansible_ssh_extra_args=-o StrictHostKeyChecking=no

--- a/hosts
+++ b/hosts
@@ -12,6 +12,7 @@ kubernetes  ansible_host=10.20.20.4
 
 [all:vars]
 advertise_masters=10.20.20.4
+#advertise_masters=k8s.localcluster.lan
 
 # SSH connection settings
 ansible_ssh_extra_args=-o StrictHostKeyChecking=no
@@ -20,4 +21,4 @@ ansible_ssh_private_key_file=/home/vagrant/ssh-private-key.pem
 
 # If advertise_masters is a DNS name and you want to provision /etc/hosts files of all your cluster hosts with IP resolution
 [etc_hosts]
-#k8s.pierre.localcluster.lan ansible_host=10.10.20.40
+#k8s.localcluster.lan ansible_host=10.10.20.4

--- a/hosts
+++ b/hosts
@@ -1,26 +1,23 @@
 
 [deploy]
-master ansible_connection=local
+kubernetes ansible_connection=local
 
 [masters]
-master  ansible_host=10.10.20.40
+kubernetes  ansible_host=10.20.20.4
 
 [etcd]
-master  ansible_host=10.10.20.40
-
+kubernetes  ansible_host=10.20.20.4
 [workers]
-worker20  ansible_host=10.10.20.50
-worker30  ansible_host=10.10.20.60
+kubernetes  ansible_host=10.20.20.4
 
 [all:vars]
-advertise_masters=k8s.pierre.localcluster.lan
-
+advertise_masters=10.20.20.4
 
 # SSH connection settings
 ansible_ssh_extra_args=-o StrictHostKeyChecking=no
 ansible_user=vagrant
 ansible_ssh_private_key_file=/home/vagrant/ssh-private-key.pem
 
-# If advertise_masters is a DNS and you want to to provision /etc/hosts file of your cluster hosts:
+# If advertise_masters is a DNS name and you want to provision /etc/hosts files of all your cluster hosts with IP resolution
 [etc_hosts]
-k8s.pierre.localcluster.lan ansible_host=10.10.20.40
+#k8s.pierre.localcluster.lan ansible_host=10.10.20.40

--- a/hosts
+++ b/hosts
@@ -13,7 +13,7 @@ worker20  ansible_host=10.10.20.50
 worker30  ansible_host=10.10.20.60
 
 [all:vars]
-advertise_ip_masters=k8s.pierre.lan
+advertise_masters=k8s.pierre.lan
 
 # SSH connection settings
 ansible_ssh_extra_args=-o StrictHostKeyChecking=no

--- a/labs/all-in-one/Vagrantfile
+++ b/labs/all-in-one/Vagrantfile
@@ -52,12 +52,16 @@ kubernetes  ansible_host=10.20.20.4
 kubernetes  ansible_host=10.20.20.4
 
 [all:vars]
-advertise_ip_masters=10.20.20.4
+advertise_masters=10.20.20.4
+#advertise_masters=kubernetes.localcluster.lan
 
 # SSH connection settings
 ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
 ansible_user=vagrant
 ansible_ssh_private_key_file=/home/vagrant/ssh-private-key.pem
+
+[etc_hosts]
+#kubernetes.localcluster.lan ansible_host=10.10.20.4
 ' > /home/vagrant/agorakube/hosts
 
 echo '

--- a/labs/multi-nodes/Vagrantfile
+++ b/labs/multi-nodes/Vagrantfile
@@ -54,12 +54,16 @@ worker2  ansible_host=10.10.20.5
 worker3  ansible_host=10.10.20.6
 
 [all:vars]
-advertise_ip_masters=10.10.20.4
+advertise_masters=10.20.20.4
+#advertise_masters=kubernetes.localcluster.lan
 
 # SSH connection settings
 ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
 ansible_user=vagrant
 ansible_ssh_private_key_file=/home/vagrant/ssh-private-key.pem
+
+[etc_hosts]
+#kubernetes.localcluster.lan ansible_host=10.10.20.4
 ' > /home/vagrant/agorakube/hosts
 
 echo '

--- a/roles/check-hosts-names/tasks/main.yaml
+++ b/roles/check-hosts-names/tasks/main.yaml
@@ -3,3 +3,5 @@
   assert:
     that:
       ansible_fqdn == inventory_hostname
+  when:
+  - inventory_hostname not in groups['etc_hosts']

--- a/roles/generate-certs/defaults/main.yaml
+++ b/roles/generate-certs/defaults/main.yaml
@@ -1,5 +1,8 @@
 ---
-advertise_ip_masters: 1.2.3.4
+advertise_ip_masters: 10.10.0.3
+
+
+
 kubernetes_service: 1.2.3.4
 
 state_or_province_name: "Ile-De-France"

--- a/roles/generate-certs/defaults/main.yaml
+++ b/roles/generate-certs/defaults/main.yaml
@@ -1,5 +1,5 @@
 ---
-advertise_ip_masters: 10.10.0.3
+advertise_masters: 10.10.0.3
 
 
 

--- a/roles/generate-certs/tasks/main.yaml
+++ b/roles/generate-certs/tasks/main.yaml
@@ -336,7 +336,7 @@
 
 - name: File generation of kubeconfig configuration for [admin] 1/4
   shell: |
-    kubectl config set-cluster default-cluster --server=https://{{ advertise_ip_masters }}:6443 \
+    kubectl config set-cluster default-cluster --server=https://{{ advertise_masters }}:6443 \
     --certificate-authority "{{ pki_path }}/intermediate/ca.crt" \
     --embed-certs
   environment:
@@ -371,7 +371,7 @@
 
 - name: File generation of kubeconfig configuration for [controller-manager] 1/4
   shell: |
-    kubectl config set-cluster default-cluster --server=https://{{ advertise_ip_masters }}:6443 \
+    kubectl config set-cluster default-cluster --server=https://{{ advertise_masters }}:6443 \
     --certificate-authority "{{ pki_path }}/intermediate/ca.crt" \
     --embed-certs
   environment:
@@ -406,7 +406,7 @@
 
 - name: File generation of kubeconfig configuration for [scheduler] 1/4
   shell: |
-    kubectl config set-cluster default-cluster --server=https://{{ advertise_ip_masters }}:6443 \
+    kubectl config set-cluster default-cluster --server=https://{{ advertise_masters }}:6443 \
     --certificate-authority "{{ pki_path }}/intermediate/ca.crt" \
     --embed-certs
   environment:
@@ -484,7 +484,7 @@
 
 - name: File generation of kubeconfig configuration for [kubelets] 1/4
   shell: |
-    kubectl config set-cluster default-cluster --server=https://{{ advertise_ip_masters }}:6443 \
+    kubectl config set-cluster default-cluster --server=https://{{ advertise_masters }}:6443 \
     --certificate-authority "{{ pki_path }}/intermediate/ca.crt" \
     --embed-certs
   environment:
@@ -577,7 +577,7 @@
 
 - name: File generation of kubeconfig configuration for [kube-proxy] 1/4
   shell: |
-    kubectl config set-cluster default-cluster --server=https://{{ advertise_ip_masters }}:6443 \
+    kubectl config set-cluster default-cluster --server=https://{{ advertise_masters }}:6443 \
     --certificate-authority "{{ pki_path }}/intermediate/ca.crt" \
     --embed-certs
   environment:

--- a/roles/generate-certs/vars/main.yaml
+++ b/roles/generate-certs/vars/main.yaml
@@ -5,6 +5,6 @@ etcd_subject: "{{ etcd_hosts_dns + ',' + etcd_hosts_ips + ',IP:127.0.0.1,DNS:loc
 master_hosts_dns: "{{ groups['masters'] | list | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}"
 master_hosts_ips: "{{ groups['masters'] | map('extract',hostvars,'ansible_host') | list | map('regex_replace', '(.*)', 'IP:\\1') | join(',')}}"
 master_custom_subject: "IP:127.0.0.1,DNS:localhost,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster,DNS:kubernetes.default.svc.cluster.local"
-kube_api_subject: "{% if advertise_ip_masters | ansible.netcommon.ipv4 %}{{ 'IP:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% else %}{{ 'DNS:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% endif %}"
+kube_api_subject: "{% if advertise_masters | ansible.netcommon.ipv4 %}{{ 'IP:' + advertise_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% else %}{{ 'DNS:' + advertise_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% endif %}"
 pki_path: "{{ data_path }}/pki"
 rotate_private_keys: False # This parametter is used to renew K8S PKI keys. Keys, CSR and CRT are renewed. If calico is used as CNI, you must retart your cluster...

--- a/roles/generate-certs/vars/main.yaml
+++ b/roles/generate-certs/vars/main.yaml
@@ -5,6 +5,6 @@ etcd_subject: "{{ etcd_hosts_dns + ',' + etcd_hosts_ips + ',IP:127.0.0.1,DNS:loc
 master_hosts_dns: "{{ groups['masters'] | list | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}"
 master_hosts_ips: "{{ groups['masters'] | map('extract',hostvars,'ansible_host') | list | map('regex_replace', '(.*)', 'IP:\\1') | join(',')}}"
 master_custom_subject: "IP:127.0.0.1,DNS:localhost,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster,DNS:kubernetes.default.svc.cluster.local"
-kube_api_subject: "{{ 'IP:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}"
+kube_api_subject: "{% if advertise_masters | ansible.netcommon.ipv4 %}{{ 'IP:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% else %}{{ 'DNS:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% endif %}"
 pki_path: "{{ data_path }}/pki"
 rotate_private_keys: False # This parametter is used to renew K8S PKI keys. Keys, CSR and CRT are renewed. If calico is used as CNI, you must retart your cluster...

--- a/roles/generate-certs/vars/main.yaml
+++ b/roles/generate-certs/vars/main.yaml
@@ -5,6 +5,6 @@ etcd_subject: "{{ etcd_hosts_dns + ',' + etcd_hosts_ips + ',IP:127.0.0.1,DNS:loc
 master_hosts_dns: "{{ groups['masters'] | list | map('regex_replace', '(.*)', 'DNS:\\1') | join(',') }}"
 master_hosts_ips: "{{ groups['masters'] | map('extract',hostvars,'ansible_host') | list | map('regex_replace', '(.*)', 'IP:\\1') | join(',')}}"
 master_custom_subject: "IP:127.0.0.1,DNS:localhost,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster,DNS:kubernetes.default.svc.cluster.local"
-kube_api_subject: "{% if advertise_masters | ansible.netcommon.ipv4 %}{{ 'IP:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% else %}{{ 'DNS:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% endif %}"
+kube_api_subject: "{% if advertise_ip_masters | ansible.netcommon.ipv4 %}{{ 'IP:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% else %}{{ 'DNS:' + advertise_ip_masters + ',' + master_hosts_dns + ',' + master_hosts_ips + ',' + master_custom_subject + ',IP:' + kubernetes_service }}{% endif %}"
 pki_path: "{{ data_path }}/pki"
 rotate_private_keys: False # This parametter is used to renew K8S PKI keys. Keys, CSR and CRT are renewed. If calico is used as CNI, you must retart your cluster...

--- a/setup-deploy.sh
+++ b/setup-deploy.sh
@@ -22,6 +22,7 @@
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python get-pip.py
         pip install ansible
+        pip install netaddr
         sudo yum install openssh-server -y
         sudo yum install git -y
         git clone https://github.com/ilkilab/agorakube.git -b core
@@ -34,6 +35,7 @@
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python get-pip.py
         pip install ansible
+        pip install netaddr
         sudo apt-get update
         sudo apt-get install -yqq  openssh-server
         git clone  https://github.com/ilkilab/agorakube.git -b core


### PR DESCRIPTION
This PR fix #222 

### Feature added
* Replace **advertise_ip_masters** by **advertise_masters** . Now, **advertise_masters** can be an IP address or a DNS name.
* Add an optional [etc_hosts] group on Agorakube that is used to provision /etc/hosts file with DNS resolution. This should be used only if **advertise_masters** is a DNS name and you don't have DNS server to resolv it's IP address.

