### PR TITLE
Fix/download k8s force restart

### DIFF
--- a/roles/setup-master/tasks/setup-master.yaml
+++ b/roles/setup-master/tasks/setup-master.yaml
@@ -14,7 +14,10 @@
     dest: /usr/local/bin
     remote_src: yes
     creates: /usr/local/bin/kubernetes/server/bin/kube-apiserver
-
+  notify:
+    - Restart kube-apiserver service
+    - Restart kube-controller-manager service
+    - Restart kube-scheduler service
 #- name: Retrive all keys to authenticate K8S service account tokens
 #  find:
 #    paths: "{{ pki_path }}/sa"

--- a/roles/setup-worker/tasks/setup-worker.yaml
+++ b/roles/setup-worker/tasks/setup-worker.yaml
@@ -31,6 +31,9 @@
     dest: /usr/local/bin
     remote_src: yes
     creates: /usr/local/bin/kubernetes/node/bin/kubelet
+  notify:
+    - restart kubelet
+    - restart kube-proxy
   when:
   - ansible_fqdn in groups['workers']
   - ansible_fqdn not in groups['masters']


### PR DESCRIPTION
This fix a bug reported at #226 by forcing Kubernetes services to restart when new K8S binaries are downloaded.