### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/actions/ansible-lint/dockerfiles/ansible-lint/v1/Dockerfile
+++ b/actions/ansible-lint/dockerfiles/ansible-lint/v1/Dockerfile
@@ -3,5 +3,5 @@ MAINTAINER Ilkilabs @ www.ilki.fr
 RUN apt update && apt install software-properties-common -yqq
 RUN apt-add-repository --yes --update ppa:ansible/ansible
 RUN apt install ansible python-pip git -yqq
-RUN pip install ansible-lint
+RUN pip install --no-cache-dir ansible-lint
 CMD ["/bin/bash"]


### PR DESCRIPTION
using --no-cache-dir flag in pip install, make sure downloaded packages
by pip don't cache on the system. This is a best practice that makes sure
to fetch from repo instead of using local cached one. Further, in the case
of Docker Containers, by restricting caching, we can reduce image size.
In terms of stats, it depends upon the number of python packages
multiplied by their respective size. e.g for heavy packages with a lot
of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>