### PR TITLE
Fix/tls valide for kubelet ip

### DIFF
--- a/roles/generate-certs/tasks/generate-kubernetes-pki.yaml
+++ b/roles/generate-certs/tasks/generate-kubernetes-pki.yaml
@@ -466,7 +466,7 @@
     country_name: "{{ agorakube_pki.infos.country }}"
     organization_name: 'system:nodes'
     use_common_name_for_san: False
-    subject_alt_name: "DNS:{{ item }}"
+    subject_alt_name: "DNS:{{ item }},IP:{{ hostvars[item].ansible_host }}"
   with_items:
     - "{{ groups['masters'] }}"
     - "{{ groups['workers'] }}"

--- a/roles/post-scripts/templates/metrics.yaml.j2
+++ b/roles/post-scripts/templates/metrics.yaml.j2
@@ -93,9 +93,8 @@ spec:
         args:
           - --cert-dir=/tmp
           - --secure-port=4443
-          - --kubelet-insecure-tls
           - --v=2
-          - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+          - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
         ports:
         - name: main-port
           containerPort: 4443


### PR DESCRIPTION
Add IPs to Kubelet CRT.

A lot of K8S CNCF projects use IP in kubelet crt to validate kubelets CRT. Agorakube used only DNS in CRT. Adding IP to kubelet crt will be usefull to help CNCF projets to validate PKI for Kubelets when needed (Fluentd, metrics-servers,...)