### PR TITLE
add ability to cleanup /etc/hosts entries

### DIFF
--- a/agorakube.yaml
+++ b/agorakube.yaml
@@ -6,6 +6,7 @@
     - connexion-to-hosts
     - check-hosts-names
     - populate_etc_hosts
+    - remove_etc_hosts
 - hosts: deploy
   become: true
   vars:

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -181,7 +181,19 @@ agorakube_features:
           nodename: "master1"
           path: /var/keycloak
 
+etc_hosts:
+  - hostname: "localhost"
+    ip: "127.0.0.1"
+
+# Populate /etc/hosts using etc_hosts inventory group
+# Note: This will not remove /etc/hosts entries when removed from inventory
 agorakube_populate_etc_hosts: True
+
+# Remove ALL /etc/hosts entries that are NOT defined in the etc_hosts group or etc_hosts variable
+agorakube_remove_etc_hosts: False
+
+# Optionally backup /etc/hosts each time a change is made
+agorakube_backup_etc_hosts: False
 
 # Security
 agorakube_encrypt_etcd_keys:

--- a/roles/remove_etc_hosts/defaults/main.yaml
+++ b/roles/remove_etc_hosts/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+backup_etc_hosts: "{{ agorakube_backup_etc_hosts }}"

--- a/roles/remove_etc_hosts/tasks/main.yaml
+++ b/roles/remove_etc_hosts/tasks/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: Remove orphaned /etc/hosts entries
+  include_tasks: remove-etc-hosts.yaml
+  when: agorakube_remove_etc_hosts | bool == True
+  tags: remove-etc-hosts

--- a/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
+++ b/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
@@ -1,0 +1,39 @@
+---
+- name: Combine etc_hosts list with etc_hosts group entries
+  set_fact:
+    etc_hosts: "{{ etc_hosts | default([]) + [{'hostname': item, 'ip': hostvars[item].ansible_host}] }}"
+  with_items:
+    - "{{ groups['etc_hosts'] }}"
+  when: hostvars[item].ansible_host not in etc_hosts | map(attribute="ip") | list
+
+- name: Slurp /etc/hosts file
+  slurp:
+    src: /etc/hosts
+  register: slurpfile
+
+- name: Create remote_etc_hosts list
+  set_fact:
+    remote_etc_hosts: "{{ remote_etc_hosts | default([]) + [{'ip': item.split(' ') | first, 'hostname': item.split(' ')[1:] | join(' ')}] }}"
+  with_items:
+    - "{{ slurpfile['content'] | b64decode | trim | split('\n') }}"
+
+- name: Update /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    backup: "{{ backup_etc_hosts | bool }}"
+    state: present
+    line: "{{ item.ip }} {{ item.hostname }}"
+  with_items:
+    - "{{ etc_hosts }}"
+  become: true
+
+- name: Cleanup /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    backup: "{{ backup_etc_hosts | bool }}"
+    state: "{{ (item.ip not in (etc_hosts | map(attribute='ip') | list)) | ternary('absent', 'present') }}"
+    line: "{{ item.ip }} {{ item.hostname }}"
+    regexp: "^{{ item.ip | regex_replace('\\.','\\.' ) }}\\s+{{ item.hostname }}"
+  with_items:
+    - "{{ remote_etc_hosts }}"
+  become: true

--- a/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
+++ b/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
@@ -31,7 +31,8 @@
   lineinfile:
     path: /etc/hosts
     backup: "{{ backup_etc_hosts | bool }}"
-    state: "{{ (item.ip not in (etc_hosts | map(attribute='ip') | list)) | ternary('absent', 'present') }}"
+    state: "{{ ((item.ip not in (etc_hosts | map(attribute='ip') | list)) or
+                (item.hostname not in (etc_hosts | map(attribute='hostname') | list))) | ternary('absent', 'present') }}"
     line: "{{ item.ip }} {{ item.hostname }}"
     regexp: "^{{ item.ip | regex_replace('\\.','\\.' ) }}\\s+{{ item.hostname }}"
   with_items:


### PR DESCRIPTION
This adds the ability to cleanup `/etc/hosts` to ensure orphaned nodes do not get left behind.

In order to make this a safe change the default behavior or agorakube is preserved and will not clean up `/etc/hosts` unless `agorakube_remove_etc_hosts` is set to `True`

Also this allows you to populate the inventory or `group_vars/all` which might be useful for certain defaults such as `127.0.0.1 localhost`, etc.

Let me know if you are interested in merging and if you have any questions or suggestions for improvement.

fixes #327