### PR TITLE
ignore /etc/hosts comments and empty lines

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -626,7 +626,9 @@ This section allows you to configure additional settings
 
 | Parameter | Description | Values |
 | --- | --- | --- |
-| `agorakube_populate_etc_hosts` | Add to all hostname/IPs of AGORAKUBE Cluster to /etc/hosts file of all hosts. | **True** *(default)* |
+| `agorakube_populate_etc_hosts` | Add all hostnames/IPs of AGORAKUBE Cluster to /etc/hosts file for all hosts. | **True** *(default)* |
+| `agorakube_remove_etc_hosts` | Remove ALL /etc/hosts entries that are NOT defined in the etc_hosts group or etc_hosts variable | **False** *(default)* |
+| `agorakube_backup_etc_hosts` | Optionally backup /etc/hosts each time a change is made | **False** *(default)* |
 | `agorakube_encrypt_etcd_keys` | Array of keys/algorith used to crypt/decrypt data in etcd? Generate with : `head -c 32 /dev/urandom | base64` | **changeME !** *(default)* |
 | `restoration_snapshot_file` | ETCD backup path to be restored | **none** *(default)* |
 | `master_custom_alt_name`  | Optional DNS alt name to be added to kube-apiserver certificate | **""** *(default)* |

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -185,7 +185,7 @@ etc_hosts:
   - hostname: "localhost"
     ip: "127.0.0.1"
 
-# Populate /etc/hosts using etc_hosts inventory group
+# Populate /etc/hosts using all inventory groups
 # Note: This will not remove /etc/hosts entries when removed from inventory
 agorakube_populate_etc_hosts: True
 

--- a/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
+++ b/roles/remove_etc_hosts/tasks/remove-etc-hosts.yaml
@@ -16,6 +16,9 @@
     remote_etc_hosts: "{{ remote_etc_hosts | default([]) + [{'ip': item.split(' ') | first, 'hostname': item.split(' ')[1:] | join(' ')}] }}"
   with_items:
     - "{{ slurpfile['content'] | b64decode | trim | split('\n') }}"
+  when:
+    - item is not regex('^#(.*)$')
+    - item | trim != ''
 
 - name: Update /etc/hosts
   lineinfile:


### PR DESCRIPTION
This is an update to #328 that makes `agorakube_remove_etc_hosts=True` more flexible allowing comments and empty lines to remain untouched in existing `/etc/hosts` files.

Also I've updated the instructions.md with the new params.