### PR TITLE
remove override_kernel_check docker setting

### DIFF
--- a/roles/install-runtimes/files/daemon.json
+++ b/roles/install-runtimes/files/daemon.json
@@ -4,8 +4,5 @@
   "log-opts": {
     "max-size": "100m"
   },
-  "storage-driver": "overlay2",
-  "storage-opts": [
-    "overlay2.override_kernel_check=true"
-  ]
+  "storage-driver": "overlay2"
 }


### PR DESCRIPTION
This setting has been deprecated and removed from docker 24.0