### PR TITLE
create docker directory on new nodes

### DIFF
--- a/roles/install-runtimes/tasks/docker.yaml
+++ b/roles/install-runtimes/tasks/docker.yaml
@@ -18,6 +18,12 @@
     path: /usr/sbin/iptables-legacy
   when: ansible_distribution|lower == 'debian'
 
+- name: Create /etc/docker directory
+  file:
+    path: /etc/docker
+    state: directory
+    mode: '0755'
+
 - name: Configure /etc/docker/daemon.json
   copy:
     dest: /etc/docker/daemon.json


### PR DESCRIPTION
Apologies, one more PR, turns out the `/etc/docker` directory doesn't exist on new nodes :stuck_out_tongue_winking_eye: 